### PR TITLE
Timezone support

### DIFF
--- a/ps.py
+++ b/ps.py
@@ -7,7 +7,7 @@ from icalendar import Calendar, Event
 
 import ps_data
 
-from util import now_tz
+from util import utc_now
 
 app = flask.Flask(__name__)
 
@@ -21,13 +21,13 @@ def next():
 
 @app.route('/previous')
 def previous():
-    events = ps_data.events(end=now_tz())
+    events = ps_data.events(end=utc_now())
     return flask.render_template('previous.html', events=events)
 
 @app.route('/next.ics')
 @app.route('/all.ics')
 def ics():
-    next_year = now_tz() + datetime.timedelta(weeks=52)
+    next_year = utc_now() + datetime.timedelta(weeks=52)
     return events_to_ical(ps_data.events(end=next_year), 'Pub Standards Events')
 
 @app.route('/event/pub-standards-<numeral>')
@@ -57,7 +57,7 @@ def about():
 
 
 def next_events():
-    now = now_tz()
+    now = utc_now()
     future = now + datetime.timedelta(weeks=52)
     return ps_data.events(start=now, end=future)
 

--- a/ps_data.py
+++ b/ps_data.py
@@ -2,6 +2,7 @@ import datetime
 import json
 import heapq
 from collections import OrderedDict
+import pytz
 
 import the_algorithm
 import roman
@@ -9,37 +10,48 @@ import inflect
 import slug
 from dateutil.relativedelta import relativedelta
 
+from util import combine_tz, now_tz
+
 p = inflect.engine()
 
 PS_LOCATION = 'The Bricklayers Arms'
 PS_ADDRESS  = '31 Gresse Street, London W1T 1QS'
 PS_STARTS   = datetime.time(18, 0, 0)
 PS_ENDS     = datetime.time(23, 30, 0)
+PS_TIMEZONE = 'Europe/London'
 PS_DESCRIPTION = 'We\'ll meet in the upstairs room as usual.'
 
 class PSEvent(object):
     def __init__(self, data={}, date=None, override=False):
         self.starts      = PS_STARTS
         self.ends        = PS_ENDS
+        self.timezone    = PS_TIMEZONE
         self.location    = PS_LOCATION
         self.address     = PS_ADDRESS
         self.name        = None
         self.description = PS_DESCRIPTION
         self.cancelled   = False
-        self.override    = override
+        self.override    = override  # used for merging iters
 
         if date is not None:
             data['date'] = date
 
         for k, v in data.items():
-            if k == 'date' and isinstance(v, unicode):
+            if k == 'date' and isinstance(v, basestring):
                 v = datetime.datetime.strptime(v, '%Y-%m-%d')
-            if k in ('starts', 'ends'):
-                v = datetime.time.strptime(v, '%H:%M')
+            if k in ('starts', 'ends') and isinstance(v, basestring):
+                v = datetime.datetime.strptime(v, '%H:%M').time()
             setattr(self, k, v)
 
+        self.tzinfo = pytz.timezone(self.timezone)
+
+        # We use local timezones because the comparisons are minimal, we don't
+        # use any timedeltas, and they're stored and displayed as local times.
+        self.start_dt = combine_tz(self.date, self.starts, self.tzinfo)
+        self.end_dt = combine_tz(self.date, self.ends, self.tzinfo)
+
     def __lt__(self, other):
-        return self.date.date() < other.date.date()
+        return self.start_dt < other.start_dt
 
     @property
     def title(self):
@@ -54,34 +66,25 @@ class PSEvent(object):
 
     @property
     def pretty_date(self):
-        return self.datetime['starts'].strftime('%A %B %d, %Y')
+        return self.start_dt.strftime('%A %B %d, %Y')
 
     @property
     def pretty_time_period(self):
-        return self.starts.strftime('%-I:%M%p') + ' - ' + self.ends.strftime('%-I:%M%p')
-
-    @property
-    def datetime(self):
-        return {
-            'starts':   datetime.datetime.combine(self.date, self.starts),
-            'ends':     datetime.datetime.combine(self.date, self.ends)
-        }
+        return self.start_dt.strftime('%-I:%M%p') + ' - ' + self.end_dt.strftime('%-I:%M%p %Z')
 
     @property
     def in_the_past(self):
-        return datetime.datetime.now() > self.datetime['ends']
+        return now_tz() > self.end_dt
 
     @property
     def time_until(self):
-        now = datetime.datetime.now()
-        starts = self.datetime['starts']
-        ends = self.datetime['ends']
-        relative = relativedelta(starts, now)
+        now = now_tz()
+        relative = relativedelta(self.start_dt, now)
         days = p.no('day', relative.days)
         hours = p.no('hour', relative.hours)
         minutes = p.no('minute', relative.minutes)
 
-        if starts < now and now < ends:
+        if self.start_dt < now and now < self.end_dt:
             return u'Happening right now! Get to the pub!'
 
         if relative.days:
@@ -113,16 +116,16 @@ def get_ps_event_by_slug(slug):
 def gen_events(start=None, end=None):
     gen = the_algorithm.gen_ps_dates(start)
     event = PSEvent(date=gen.next())
-    while not end or event.datetime['ends'] < end:
+    while not end or event.end_dt < end:
         yield event
         event = PSEvent(date=gen.next())
 
 def get_manual_ps_events(start=None, end=None):
     for stringdate, event in load_ps_data().items():
         event = PSEvent(event, date=stringdate, override=True)
-        if start and event.datetime['ends'] < start:
+        if start and event.end_dt < start:
             continue
-        if not end or event.datetime['ends'] < end:
+        if not end or event.end_dt < end:
             yield event
 
 # heapq.merge is not stable, however the merge guaranteed overrides will be sequential

--- a/ps_data.py
+++ b/ps_data.py
@@ -25,7 +25,6 @@ class PSEvent(object):
     def __init__(self, data={}, date=None, override=False):
         self.starts      = PS_STARTS
         self.ends        = PS_ENDS
-        self.timezone    = PS_TIMEZONE
         self.location    = PS_LOCATION
         self.address     = PS_ADDRESS
         self.name        = None
@@ -43,7 +42,7 @@ class PSEvent(object):
                 v = datetime.datetime.strptime(v, '%H:%M').time()
             setattr(self, k, v)
 
-        self.tzinfo = pytz.timezone(self.timezone)
+        self.tzinfo = pytz.timezone(PS_TIMEZONE)
 
         # We use local timezones because the comparisons are minimal, we don't
         # use any timedeltas, and they're stored and displayed as local times.
@@ -51,7 +50,7 @@ class PSEvent(object):
         self.end_dt = combine_tz(self.date, self.ends, self.tzinfo)
 
     def __lt__(self, other):
-        return self.start_dt < other.start_dt
+        return self.date.date() < other.date.date()
 
     @property
     def title(self):

--- a/ps_data.py
+++ b/ps_data.py
@@ -10,7 +10,7 @@ import inflect
 import slug
 from dateutil.relativedelta import relativedelta
 
-from util import combine_tz, now_tz
+from util import combine_tz, utc_now
 
 p = inflect.engine()
 
@@ -74,11 +74,11 @@ class PSEvent(object):
 
     @property
     def in_the_past(self):
-        return now_tz() > self.end_dt
+        return utc_now() > self.end_dt
 
     @property
     def time_until(self):
-        now = now_tz()
+        now = utc_now()
         relative = relativedelta(self.start_dt, now)
         days = p.no('day', relative.days)
         hours = p.no('hour', relative.hours)

--- a/tests/test_ps_data.py
+++ b/tests/test_ps_data.py
@@ -79,8 +79,7 @@ class ValidateData(unittest.TestCase):
         for datestr, event in self.events.items():
 
             event_date = datetime.strptime(datestr, '%Y-%m-%d')
-            timezone = event.get('timezone', 'Europe/London')
-            tzinfo = pytz.timezone(timezone)
+            tzinfo = pytz.timezone('Europe/London')
             if 'starts' in event:
                 starts = datetime.strptime(event['starts'], '%H:%M').time()
                 combine_tz(event_date, starts, tzinfo)

--- a/tests/test_ps_data.py
+++ b/tests/test_ps_data.py
@@ -1,10 +1,14 @@
 import unittest
 import ps_data
 import the_algorithm
-from datetime import datetime
+from datetime import datetime, timedelta
+import pytz
 
 def parse_datestr(datestr):
     return datetime.strptime(datestr, '%Y-%m-%d')
+
+def utc_datetime(year, month, day, hour=0, minute=0, second=0, microsecond=0):
+    return datetime(year, month, day, hour, minute, second, microsecond, pytz.UTC)
 
 def is_algorithmic_ps_date(ev_datestr):
     # Fields required vary depending on whether this is Pub or Substandards
@@ -67,12 +71,38 @@ class ValidateData(unittest.TestCase):
         assert dates == sorted(dates), 'Events are not in date order'
         assert datestrs == sorted(datestrs), 'Events are not in strict order'
 
-    def test_datetimes_unambiguous(self):
-        # Check that the start time in the local timezone isn't an unambiguous time
-        pass
+    def test_invalid_times(self):
+        def combine_tz(date, time, tzinfo):
+            dt = datetime.combine(date, time)
+            return tzinfo.localize(dt, is_dst=None)
+
+        for datestr, event in self.events.items():
+
+            event_date = datetime.strptime(datestr, '%Y-%m-%d')
+            timezone = event.get('timezone', 'Europe/London')
+            tzinfo = pytz.timezone(timezone)
+            if 'starts' in event:
+                starts = datetime.strptime(event['starts'], '%H:%M').time()
+                combine_tz(event_date, starts, tzinfo)
+
+            if 'ends' in event:
+                ends = datetime.strptime(event['ends'], '%H:%M').time()
+                combine_tz(event_date, ends, tzinfo)
 
 
 class TestFormatting(unittest.TestCase):
+
+    def test_events_construct(self):
+        manual_events = list(ps_data.get_manual_ps_events())
+
+        next_year = datetime.utcnow().replace(tzinfo=pytz.UTC) + timedelta(weeks=52)
+        end = max(next_year, manual_events[-1].end_dt)
+        all_events = list(ps_data.events(end=end))
+
+        # As there's no __eq__ for PSEvent yet
+        manual_start_dts = [e.start_dt for e in manual_events]
+        all_start_dts = [e.start_dt for e in all_events]
+        assert set(all_start_dts) > set(manual_start_dts)
 
     def test_override(self):
         ps_100 = ps_data.get_ps_event_by_number(100)
@@ -81,77 +111,65 @@ class TestFormatting(unittest.TestCase):
     # For now, don't test .date, as it's either date() or datetime(),
     # depending on whether the event is from the algorithm or not
 
-    def test_ps_ranges(self):
-        first_ps = ps_data.gen_events(start=datetime(2005, 12, 14)).next()
-        dt = first_ps.datetime
-        assert dt['starts'] == datetime(2005, 12, 15, 18, 0), '%s is wrong start time' % dt['starts']
+    def assertStartsAt(self, event, dt):
+        assert event.start_dt == dt, '%r is wrong start time' % event.start_dt
 
-        second_ps = ps_data.gen_events(start=datetime(2005, 12, 16)).next()
-        dt = second_ps.datetime
-        assert dt['starts'] == datetime(2006, 1, 12, 18, 0), '%s is wrong start time' % dt['starts']
+    def test_ps_ranges(self):
+        first_ps = ps_data.gen_events(start=utc_datetime(2005, 12, 14)).next()
+        self.assertStartsAt(first_ps, utc_datetime(2005, 12, 15, 18, 0))
+
+        second_ps = ps_data.gen_events(start=utc_datetime(2005, 12, 16)).next()
+        self.assertStartsAt(second_ps, utc_datetime(2006, 1, 12, 18, 0))
 
     def test_ps_ranges_same_day(self):
-        first_ps = ps_data.gen_events(start=datetime(2005, 12, 15)).next()
-        dt = first_ps.datetime
-        assert dt['starts'] == datetime(2005, 12, 15, 18, 0), '%s is wrong start time' % dt['starts']
+        first_ps = ps_data.gen_events(start=utc_datetime(2005, 12, 15)).next()
+        self.assertStartsAt(first_ps, utc_datetime(2005, 12, 15, 18, 0))
 
     def test_manual_ps_ranges(self):
-        first_manual_ps = ps_data.get_manual_ps_events(start=datetime(2006, 9, 25)).next()
-        dt = first_manual_ps.datetime
-        assert dt['starts'] == datetime(2006, 9, 25, 18, 0), '%s is wrong start time' % dt['starts']
+        first_manual_ps = ps_data.get_manual_ps_events(start=utc_datetime(2006, 9, 25)).next()
+        self.assertStartsAt(first_manual_ps, utc_datetime(2006, 9, 25, 17, 0))
 
-        second_manual_ps = ps_data.get_manual_ps_events(start=datetime(2006, 9, 26)).next()
-        dt = second_manual_ps.datetime
-        assert dt['starts'] == datetime(2007, 2, 1, 18, 0), '%s is wrong start time' % dt['starts']
+        second_manual_ps = ps_data.get_manual_ps_events(start=utc_datetime(2006, 9, 26)).next()
+        self.assertStartsAt(second_manual_ps, utc_datetime(2007, 2, 1, 18, 0))
 
     def test_merged_ranges_algorithmic(self):
-        first_ps = ps_data.events(start=datetime(2005, 12, 14)).next()
-        dt = first_ps.datetime
-        assert dt['starts'] == datetime(2005, 12, 15, 18, 0), '%s is wrong start time' % dt['starts']
+        first_ps = ps_data.events(start=utc_datetime(2005, 12, 14)).next()
+        self.assertStartsAt(first_ps, utc_datetime(2005, 12, 15, 18, 0))
 
-        second_ps = ps_data.events(start=datetime(2005, 12, 16)).next()
-        dt = second_ps.datetime
-        assert dt['starts'] == datetime(2006, 1, 12, 18, 0), '%s is wrong start time' % dt['starts']
+        second_ps = ps_data.events(start=utc_datetime(2005, 12, 16)).next()
+        self.assertStartsAt(second_ps, utc_datetime(2006, 1, 12, 18, 0))
 
     def test_merged_ranges_algorithmic_same_day(self):
-        first_ps = ps_data.events(start=datetime(2005, 12, 15)).next()
-        dt = first_ps.datetime
-        assert dt['starts'] == datetime(2005, 12, 15, 18, 0), '%s is wrong start time' % dt['starts']
+        first_ps = ps_data.events(start=utc_datetime(2005, 12, 15)).next()
+        self.assertStartsAt(first_ps, utc_datetime(2005, 12, 15, 18, 0))
 
     def test_merged_ranges_manual(self):
-        first_manual_ps = ps_data.events(start=datetime(2006, 9, 24)).next()
-        dt = first_manual_ps.datetime
-        assert dt['starts'] == datetime(2006, 9, 25, 18, 0), '%s is wrong start time' % dt['starts']
+        first_manual_ps = ps_data.events(start=utc_datetime(2006, 9, 24)).next()
+        self.assertStartsAt(first_manual_ps, utc_datetime(2006, 9, 25, 17, 0))
 
-        first_manual_ps = ps_data.events(start=datetime(2006, 9, 25)).next()
-        dt = first_manual_ps.datetime
-        assert dt['starts'] == datetime(2006, 9, 25, 18, 0), '%s is wrong start time' % dt['starts']
+        first_manual_ps = ps_data.events(start=utc_datetime(2006, 9, 25)).next()
+        self.assertStartsAt(first_manual_ps, utc_datetime(2006, 9, 25, 17, 0))
 
-        first_post_manual_ps = ps_data.events(start=datetime(2006, 9, 26)).next()
-        dt = first_post_manual_ps.datetime
-        assert dt['starts'] == datetime(2006, 10, 12, 18, 0), '%s is wrong start time' % dt['starts']
+        first_post_manual_ps = ps_data.events(start=utc_datetime(2006, 9, 26)).next()
+        self.assertStartsAt(first_post_manual_ps, utc_datetime(2006, 10, 12, 17, 0))
 
     def test_substandards_slug(self):
         ss_pista = ps_data.get_ps_event_by_slug('substandards-pista')
-        dt = ss_pista.datetime
-        assert dt['starts'] == datetime(2007, 2, 1, 18, 0), '%r is wrong start time' % dt['starts']
+        self.assertStartsAt(ss_pista, utc_datetime(2007, 2, 1, 18, 0))
 
         assert ps_data.get_ps_event_by_slug('substandards-Pista') is None, 'Invalid slug matched'
 
     def test_substandards_slug_with_hyphens(self):
         first_ss = ps_data.get_ps_event_by_slug('mid-pub-standards-non-pub-standards-pub-standards')
-        dt = first_ss.datetime
-        assert dt['starts'] == datetime(2006, 9, 25, 18, 0), '%r is wrong start time' % dt['starts']
+        self.assertStartsAt(first_ss, utc_datetime(2006, 9, 25, 17, 0))
 
     @unittest.skip('Currently no way to test PS slugs')
     def test_manual_ps_slugs(self):
         ps_65 = ps_data.get_ps_event_by_slug('pubstandards-lxv')
-        dt = ps_65.datetime
-        assert dt['starts'] == datetime(2005, 12, 14, 18, 0), '%r is wrong start time' % dt['starts']
+        self.assertStartsAt(ps_65, utc_datetime(2005, 12, 14, 18, 0))
 
         ps_100 = ps_data.get_ps_event_by_slug('pubstandards-c')
-        dt = ps_100.datetime
-        assert dt['starts'] == datetime(2014, 3, 13, 18, 0), '%r is wrong start time' % dt['starts']
+        self.assertStartsAt(ps_100, utc_datetime(2014, 3, 13, 18, 0))
 
     def test_cancelled_event(self):
         ss_pista = ps_data.get_ps_event_by_slug('substandards-pista')

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,18 @@
+import the_algorithm
+from datetime import datetime
+import pytz
+
+def parse_datestr(datestr):
+    return datetime.strptime(datestr, '%Y-%m-%d')
+
+def is_algorithmic_ps_date(ev_datestr):
+    # Fields required vary depending on whether this is Pub or Substandards
+    # This should probably be separated out in the data for ease of testing
+    ev_date = parse_datestr(ev_datestr)
+    day = the_algorithm.calc_middle_thursday(ev_date.year, ev_date.month)
+    return day == ev_date.day
+
+
+def utc_datetime(year, month, day, hour=0, minute=0, second=0, microsecond=0):
+    return datetime(year, month, day, hour, minute, second, microsecond, pytz.UTC)
+

--- a/util.py
+++ b/util.py
@@ -1,0 +1,10 @@
+from datetime import datetime
+import pytz
+
+
+def combine_tz(date, time, tzinfo):
+    dt = datetime.combine(date, time)
+    return tzinfo.localize(dt, is_dst=None)
+
+def utc_now():
+    return datetime.utcnow().replace(tzinfo=pytz.UTC)


### PR DESCRIPTION
This should make the website work OK with timezones. We don't include VTIMEZONE blocks in the .ics, but that doesn't seem to break Google Calendar.

I also haven't bothered fixing/testing the_algorithm.next_ps_date because it's not used. But we're unlikely to call that from the website anyway.

Should fix #9.

Currently running on ps.rack.ms