### PR TITLE
Make time_until in PSEvent cope with 0 days

### DIFF
--- a/ps_data.py
+++ b/ps_data.py
@@ -6,13 +6,10 @@ import pytz
 
 import the_algorithm
 import roman
-import inflect
 import slug
 from dateutil.relativedelta import relativedelta
 
-from util import combine_tz, utc_now
-
-p = inflect.engine()
+from util import combine_tz, utc_now, format_relative_time
 
 PS_LOCATION = 'The Bricklayers Arms'
 PS_ADDRESS  = '31 Gresse Street, London W1T 1QS'
@@ -79,20 +76,11 @@ class PSEvent(object):
     def time_until(self):
         now = utc_now()
         relative = relativedelta(self.start_dt, now)
-        days = p.no('day', relative.days)
-        hours = p.no('hour', relative.hours)
-        minutes = p.no('minute', relative.minutes)
 
         if self.start_dt < now and now < self.end_dt:
             return u'Happening right now! Get to the pub!'
 
-        if relative.days:
-            return u'In %s, %s and %s' % ( days, hours, minutes )
-        else:
-            if relative.hours:
-                return u'In %s and %s' % ( hours, minutes )
-            else:
-                return u'In %s' % minutes
+        return format_relative_time(relative)
 
 def load_ps_data():
     return json.load(

--- a/util.py
+++ b/util.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 import pytz
+import inflect
 
+p = inflect.engine()
 
 def combine_tz(date, time, tzinfo):
     dt = datetime.combine(date, time)
@@ -8,3 +10,16 @@ def combine_tz(date, time, tzinfo):
 
 def utc_now():
     return datetime.utcnow().replace(tzinfo=pytz.UTC)
+
+def format_relative_time(relative):
+    date_part_names = 'year month day hour minute'.split()
+
+    date_parts = zip(date_part_names, [getattr(relative, date_part+'s') for date_part in date_part_names])
+    formatted = [p.no(date_part, value) for (date_part, value) in date_parts if value]
+
+    rest, tail = formatted[:-1], formatted[-1]
+
+    if rest:
+        return u'In %s, and %s' % ( ', '.join(rest), tail )
+    else:
+        return u'In %s' % ( tail )


### PR DESCRIPTION
When relativedelta reports 0 days it might mean that it's exactly 1 month until the next event, not that it's only a few hours away because relativedelta rolls day differences of more than a month up into the months attribute (ditto for more months than a year).  To solve this we collapse down any attribute from the relative date that is 0 and then combine the rest as a sentence.

We've also moved the formatting into a global helper in util.py in case it's useful elsewhere.

I spotted this when looking at the site today (17th Aug) and it said the next PS was in 4 hours, when it's actually on 17th Sept and 1 month and 4 hours away.

Not got any tests on this because I'm not a pythonista by trade so I'm not up on the testing framework I should use.  Point me in the right direction and I'll redo (that goes double for any extremely non-python-y things I've done in the fix).