### PR TITLE
Provide description for Substandards Corked

### DIFF
--- a/ps_data.json
+++ b/ps_data.json
@@ -288,7 +288,8 @@
     "2016-04-01": {
         "name": "Substandards Corked",
         "location": "The Winemakers Club",
-        "address": "41a Farringdon St, London EC4A 4AN"
+        "address": "41a Farringdon St, London EC4A 4AN",
+        "description": "We're reliably informed it's not just for wine."
     }
 }
 


### PR DESCRIPTION
Turns out the software puts the Pubstandards description in as default.

This should really be fixed in code not data, but I don't have time for that.