### PR TITLE
Rework constructor of PSEvent

### DIFF
--- a/templates/event.html
+++ b/templates/event.html
@@ -11,6 +11,8 @@
       <div class='description'>
       {{ event.description|safe }}
       </div>
+    {% elif not event.override and not event.in_the_past %}
+      We'll meet in the upstairs room as usual.
     {% endif %}
   {% endif %}
 </li>

--- a/templates/homepage.html
+++ b/templates/homepage.html
@@ -23,6 +23,8 @@
         </p>
         {% if event.description %}
           <p class='description'>{{ event.description }}</p>
+        {% elif not event.override and not event.in_the_past %}
+          We'll meet in the upstairs room as usual.
         {% endif %}
       {% endif %}
     </li>

--- a/tests/test_ps_data.py
+++ b/tests/test_ps_data.py
@@ -1,4 +1,5 @@
 import unittest
+import doctest
 import ps_data
 from test_util import parse_datestr, is_algorithmic_ps_date, utc_datetime
 from datetime import datetime, timedelta
@@ -215,4 +216,9 @@ class TestLookups(unittest.TestCase):
 
         check_event_queries_for_starts(begin_dst)
         check_event_queries_for_starts(end_dst)
+
+def test_doctests():
+    results = doctest.testmod(ps_data)
+    if results.failed:
+        raise Exception(results)
 

--- a/tests/test_ps_data.py
+++ b/tests/test_ps_data.py
@@ -85,17 +85,13 @@ class TestLookups(unittest.TestCase):
         end = max(next_year, manual_events[-1].end_dt)
         all_events = list(ps_data.events(end=end))
 
-        # As there's no __eq__ for PSEvent yet
-        manual_start_dts = [e.start_dt for e in manual_events]
-        all_start_dts = [e.start_dt for e in all_events]
-        assert set(all_start_dts) > set(manual_start_dts)
+        manual_dates = [e.date for e in manual_events]
+        all_dates = [e.date for e in all_events]
+        assert set(all_dates) > set(manual_dates)
 
     def test_override(self):
         ps_100 = ps_data.get_ps_event_by_number(100)
         assert 'ONE HUNDREDTH' in ps_100.description
-
-    # For now, don't test .date, as it's either date() or datetime(),
-    # depending on whether the event is from the algorithm or not
 
     def assertStartsAt(self, event, dt):
         assert event.start_dt == dt, '%r is wrong start time' % event.start_dt


### PR DESCRIPTION
Rework constructor of PSEvent so that it always take a date, and the override attribute is accurate. This allows us to compare two PSEvents for equality and use .override in templates.

Fixes #8, #15 and #22
