### PR TITLE
Fix some event metadata

### DIFF
--- a/ps_data.py
+++ b/ps_data.py
@@ -75,7 +75,8 @@ class PSEvent(object):
                 if venue.from_date < self.date.date() and (venue.until_date is None or venue.until_date > self.date.date()):
                     self.location = venue.name
                     self.address = venue.address
-                    self.description = venue.description
+                    if self.description is None:
+                        self.description = venue.description
                     break
         if self.location is None:
             # For some reason couldn't find it, use last venue in the list in the hope

--- a/ps_data.py
+++ b/ps_data.py
@@ -70,12 +70,13 @@ class PSEvent(object):
                 v = datetime.datetime.strptime(v, "%H:%M").time()
             setattr(self, k, v)
 
-        for venue in VENUES:
-            if venue.from_date < self.date.date() and (venue.until_date is None or venue.until_date > self.date.date()):
-                self.location = venue.name
-                self.address = venue.address
-                self.description = venue.description
-                break
+        if self.location is None:
+            for venue in VENUES:
+                if venue.from_date < self.date.date() and (venue.until_date is None or venue.until_date > self.date.date()):
+                    self.location = venue.name
+                    self.address = venue.address
+                    self.description = venue.description
+                    break
         if self.location is None:
             # For some reason couldn't find it, use last venue in the list in the hope
             # that "current" is more helpful than blank or exploding.

--- a/templates/event.html
+++ b/templates/event.html
@@ -5,7 +5,7 @@
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@pubstandards" />
 <meta property="og:title" content="{{event.name}}" />
-<meta property="og:description" content="{{event.description|truncate(190)}}" />
+{% if event.description %}<meta property="og:description" content="{{event.description|truncate(190)}}" />{% endif %}
 <meta property="og:image" content="https://london.pubstandards.com/static/beer_mat.jpg" />
 <meta property="og:url" content="https://london.pubstandards.com{{url_for('other_event', slug=event.slug)}}" />
 {% endblock %}


### PR DESCRIPTION
👋 Oh, hello. It's been a while!

I happened to visit the Pub Standards site this week because I was trying to remember the name of a pub we'd been to for Substandards one time, and I noticed all the old Substandards events claimed to be at the Bricklayers, which would be a flagrant breach of The Rules.

This PR should restore the venue information and also the custom description of Pub Standards C, so I now finally know that the pub I was thinking of was the Winemakers Club.